### PR TITLE
feat: extract both chart links and chart embeds

### DIFF
--- a/process-db/extract-links.py
+++ b/process-db/extract-links.py
@@ -6,8 +6,11 @@ from rich import print
 from rich.progress import track
 import re
 
-grapherUrlRegex = re.compile("^http(s)?://(www\\.)?ourworldindata.org/grapher/(?P<slug>[^?]+)")
+grapherUrlRegex = re.compile(
+    "^http(s)?://(www\\.)?ourworldindata.org/grapher/(?P<slug>[^?]+)"
+)
 internalUrlRegex = re.compile("^http(s)?://(www\\.)?ourworldindata.org/")
+
 
 def postprocess(args):
     if len(args) != 1:
@@ -17,15 +20,18 @@ def postprocess(args):
         connection.row_factory = sqlite3.Row
         with closing(connection.cursor()) as cursor:
             print("Fetching redirects")
-            grapher_rows = cursor.execute("""
+            grapher_rows = cursor.execute(
+                """
             SELECT chart_id as id, slug FROM chart_slug_redirects
             UNION
             SELECT id, JSON_EXTRACT(config, '$.slug') as slug FROM charts
-            """)
-            chart_slugs_to_ids = { row["slug"] : row["id"] for row in grapher_rows }
+            """
+            )
+            chart_slugs_to_ids = {row["slug"]: row["id"] for row in grapher_rows}
 
             print("Creating new link tables")
-            cursor.execute("""
+            cursor.execute(
+                """
             CREATE TABLE IF NOT EXISTS post_links (
                 `id` integer NOT NULL PRIMARY KEY,
                 `postId` integer NOT NULL,
@@ -33,9 +39,11 @@ def postprocess(args):
                 `kind` TEXT,
                 CONSTRAINT `FK_post_links_postId` FOREIGN KEY (`postId`) REFERENCES `posts` (`id`) ON DELETE CASCADE
             )  ;
-            """)
+            """
+            )
 
-            cursor.execute("""
+            cursor.execute(
+                """
             CREATE TABLE IF NOT EXISTS post_charts  (
                 `postId` integer NOT NULL,
                 `chartId` integer NOT NULL,
@@ -43,49 +51,90 @@ def postprocess(args):
                 CONSTRAINT `FK_post_charts_chartId` FOREIGN KEY (`chartId`) REFERENCES `charts` (`id`) ON DELETE CASCADE,
                 CONSTRAINT `FK_post_charts_postId` FOREIGN KEY (`postId`) REFERENCES `posts` (`id`) ON DELETE CASCADE
             ) ;
-            """)
+            """
+            )
 
             rows = cursor.execute("SELECT id, title, content from posts").fetchall()
             for row in track(rows, description="Processing posts..."):
                 soup = BeautifulSoup(row["content"], "html.parser")
 
-                links = list(filter(lambda link: link is not None, map(lambda link: link.get("href"), soup.find_all("a"))))
-                internal_links = [ link for link in links if internalUrlRegex.match(link) ]
-                params = [ {"postId": row["id"], "link": link, "kind": "internal-link" } for link in internal_links ]
-                cursor.executemany("""
+                links = list(
+                    filter(
+                        lambda link: link is not None,
+                        map(lambda link: link.get("href"), soup.find_all("a")),
+                    )
+                )
+                internal_links = [
+                    link for link in links if internalUrlRegex.match(link)
+                ]
+                params = [
+                    {"postId": row["id"], "link": link, "kind": "internal-link"}
+                    for link in internal_links
+                ]
+                cursor.executemany(
+                    """
                 INSERT INTO post_links(postId, link, kind) VALUES (:postId, :link, :kind)
-                """, params)
+                """,
+                    params,
+                )
 
-                external_links = [ link for link in links if internalUrlRegex.match(link) is None ]
-                params = [ {"postId": row["id"], "link": link, "kind": "external-link" } for link in external_links ]
-                cursor.executemany("""
+                external_links = [
+                    link for link in links if internalUrlRegex.match(link) is None
+                ]
+                params = [
+                    {"postId": row["id"], "link": link, "kind": "external-link"}
+                    for link in external_links
+                ]
+                cursor.executemany(
+                    """
                 INSERT INTO post_links(postId, link, kind) VALUES (:postId, :link, :kind)
-                """, params)
-
+                """,
+                    params,
+                )
 
                 images = map(lambda img: img.get("src"), soup.find_all("img"))
-                params = [ {"postId": row["id"], "link": image, "kind": "image" } for image in images ]
-                cursor.executemany("""
+                params = [
+                    {"postId": row["id"], "link": image, "kind": "image"}
+                    for image in images
+                ]
+                cursor.executemany(
+                    """
                 INSERT INTO post_links(postId,
                 link, kind) VALUES (:postId, :link, :kind)
-                """, params)
-
+                """,
+                    params,
+                )
 
                 iframes = map(lambda iframe: iframe.get("src"), soup.find_all("iframe"))
-                grapher_links = [ match.groupdict()["slug"] for match in ( grapherUrlRegex.match(iframe) for iframe in iframes ) if match is not None]
-                grapher_ids = { chart_slugs_to_ids.get(slug) for slug in grapher_links if slug in chart_slugs_to_ids }
-                unresolved_grapher_slugs = [ slug for slug in grapher_links if slug not in chart_slugs_to_ids]
+                grapher_links = [
+                    match.groupdict()["slug"]
+                    for match in (grapherUrlRegex.match(iframe) for iframe in iframes)
+                    if match is not None
+                ]
+                grapher_ids = {
+                    chart_slugs_to_ids.get(slug)
+                    for slug in grapher_links
+                    if slug in chart_slugs_to_ids
+                }
+                unresolved_grapher_slugs = [
+                    slug for slug in grapher_links if slug not in chart_slugs_to_ids
+                ]
 
                 if unresolved_grapher_slugs:
-                    print(f"[yellow]The following slugs could not be resolved: {', '.join(unresolved_grapher_slugs)}")
+                    print(
+                        f"[yellow]The following slugs could not be resolved: {', '.join(unresolved_grapher_slugs)}"
+                    )
 
-                params = [ {"postId": row["id"], "chartId": id } for id in grapher_ids ]
-                cursor.executemany("""
+                params = [{"postId": row["id"], "chartId": id} for id in grapher_ids]
+                cursor.executemany(
+                    """
                 INSERT INTO post_charts(postId, chartId) VALUES (:postId, :chartId)
-                """, params)
+                """,
+                    params,
+                )
             print("[green]All done")
             connection.commit()
 
 
 if __name__ == "__main__":
-   postprocess(sys.argv[1:])
+    postprocess(sys.argv[1:])


### PR DESCRIPTION
As identified by Ed in https://github.com/owid/owid-issues/issues/98#issuecomment-1205001994, we were only filling the `post_charts` table with `iframe` embeds and not with regular links to charts.

Now we're doing both :) They are identified by `kind=link` or `kind=embed` in the `post_charts` table.

This code is absolutely not tested, because I wouldn't know how to do that locally.