### PR TITLE
feat: add view `charts_broken_origin_url`

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -100,3 +100,8 @@ databases:
         description:
       charts_potential_duplicates:
         description:
+      charts_broken_origin_url:
+        description: |
+          Charts where there's an origin URL set, but no post exists for that URL.
+          Sometimes this just means that a redirect has been set up in the meantime, and so the link still works for the user.
+          However, in this case we still display the outdated post URL with the chart - and, crucially, there will not be any "related charts" presented to the user, since these are based on the origin URL and don't take redirects into account.


### PR DESCRIPTION
Adds a view for
> Charts where there's an origin URL set, but no post exists for that URL.
Sometimes this just means that a redirect has been set up in the meantime, and so the link still works for the user.
However, in this case we still display the outdated post URL with the chart - and, crucially, there will not be any "related charts" presented to the user, since these are based on the origin URL and don't take redirects into account.

[You can see the result of this query here.](https://owid-datasette-y43qr.ondigitalocean.app/owid?sql=WITH+chartOriginUrl+AS+%28%0D%0ASELECT%0D%0A++++id+AS+chartId%2C%0D%0A++++slug+AS+chartSlug%2C%0D%0A++++%22https%3A%2F%2Fowid.cloud%2Fadmin%2Fcharts%2F%22+%7C%7C+id+%7C%7C+%22%2Fedit%22+AS+chartEditLink%2C%0D%0A++++config+-%3E%3E+%22%24.originUrl%22+AS+originUrlAsAuthored%2C%0D%0A++++trim%28%0D%0A++++++++regexp_match%28%0D%0A++++++++++++%27%5E.*%5BOo%5Dur%5BWw%5Dorld%5BIi%5Dn%5BDd%5Data.org%2F%28.%2B%29%24%27%2C%0D%0A++++++++++++config+-%3E%3E+%22%24.originUrl%22%0D%0A++++++++%29%2C%0D%0A++++++++%27%2F%27%0D%0A++++%29+AS+originUrlPostSlug%0D%0AFROM%0D%0A++++charts%0D%0AWHERE%0D%0A++++originUrlAsAuthored+IS+NOT+NULL%0D%0A++++AND+originUrlAsAuthored+IS+NOT+%22%22%0D%0A++++AND+originUrlAsAuthored+not+like+%22%25tinyco.re%25%22%0D%0A%29%0D%0ASELECT%0D%0Ac.chartId%2C%0D%0Ac.chartSlug%2C%0D%0Ac.chartEditLink%2C%0D%0Ac.originUrlAsAuthored%2C%0D%0Ac.originUrlPostSlug%2C%0D%0ACASE%0D%0A++++WHEN+c.originUrlPostSlug+IS+NOT+NULL%0D%0A++++THEN+%22https%3A%2F%2Fourworldindata.org%2F%22+%7C%7C+c.originUrlPostSlug%0D%0A++++ELSE+NULL%0D%0AEND+AS+originUrlPostLink%0D%0AFROM%0D%0AchartOriginUrl+c%0D%0ALEFT+JOIN+posts+p+ON+p.slug+%3D+c.originUrlPostSlug%0D%0AWHERE%0D%0Ap.id+IS+NULL)