### PR TITLE
feat: extract prominent links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 owid.sqlite
-owid.db
-owid.db.gz
-owid.sqlite.gz
-owid.db
+*.db
+*.db.gz
+*.sqlite.gz
 .env

--- a/process-db/extract-links.py
+++ b/process-db/extract-links.py
@@ -138,6 +138,7 @@ def postprocess(args):
             for row in track(rows, description="Processing posts..."):
                 soup = BeautifulSoup(row["content"], "html.parser")
 
+                # Extract normal links, i.e. simple <a> tags
                 links = list(
                     filter(
                         lambda link: link is not None,
@@ -172,6 +173,9 @@ def postprocess(args):
                     params,
                 )
 
+                extract_chart_references(links, "link", row, chart_slugs_to_ids, cursor)
+
+                # Extract images, i.e. <img> tags
                 images = map(lambda img: img.get("src"), soup.find_all("img"))
                 params = [
                     {"postId": row["id"], "link": image, "kind": "image"}
@@ -185,6 +189,7 @@ def postprocess(args):
                     params,
                 )
 
+                # Extract iframes, i.e. embedded graphers
                 iframe_links = [
                     iframe.get("src")
                     for iframe in soup.find_all("iframe")
@@ -192,13 +197,6 @@ def postprocess(args):
                 ]
                 extract_chart_references(
                     iframe_links, "embed", row, chart_slugs_to_ids, cursor
-                )
-
-                link_hrefs = [
-                    link.get("href") for link in soup.find_all("a") if link.get("href")
-                ]
-                extract_chart_references(
-                    link_hrefs, "link", row, chart_slugs_to_ids, cursor
                 )
 
             print("[green]All done")


### PR DESCRIPTION
This adds extraction of prominent links (which are `<!-- wp:owid/prominent-block -->` comments).
These will be handled just like other links, and added to the tables `post_links`, `post_charts`, and `post_charts_broken_links`.

I tested this locally and everything works flawlessly.