### PR TITLE
fix: prepare for generated json columns

### DIFF
--- a/process-db/postprocess-db.py
+++ b/process-db/postprocess-db.py
@@ -120,10 +120,6 @@ def postprocess(args):
                 ADD COLUMN subtitle TEXT GENERATED ALWAYS as (JSON_EXTRACT(config, '$.subtitle'))  VIRTUAL;
             ALTER TABLE charts
                 ADD COLUMN note TEXT GENERATED ALWAYS as (JSON_EXTRACT(config, '$.note'))  VIRTUAL;
-            ALTER TABLE charts
-                ADD COLUMN slug TEXT GENERATED ALWAYS as (JSON_EXTRACT(config, '$.slug'))  VIRTUAL;
-            ALTER TABLE charts
-                ADD COLUMN type TEXT GENERATED ALWAYS as (JSON_EXTRACT(config, '$.type'))  VIRTUAL;
                 """
             )
 

--- a/sqlite-from-mysql.sh
+++ b/sqlite-from-mysql.sh
@@ -14,7 +14,9 @@ source .env set
 set +o allexport
 
 # Run mysqldump with a subset of tables and some flags to bring it into the required format, the
-# pipe this into mysql2sqlite and pipe this into sqlite3 to created owid.db
+# pipe this into mysql2sqlite and pipe this into sqlite3 to create owid.db.
+# we need the additional `sed` command to replace string literals like `_utf8mb4'$.slug'`, which
+# mysql generates for generated columns, with just `$.slug`.
 mysqldump --skip-extended-insert --no-tablespaces --column-statistics=0 --compact --port \
     $DB_PORT --password=$DB_PASSWD --user $DB_USER --host $DB_HOST $DB_NAME \
     users \
@@ -38,6 +40,7 @@ mysqldump --skip-extended-insert --no-tablespaces --column-statistics=0 --compac
     posts_gdocs_links \
     posts_gdocs_x_tags \
   | ./mysql2sqlite - \
+  | sed 's/_utf8mb4//g' \
   | sqlite3 owid-public.db
 # Run the postprocess-db python script. This is the place to censor some rows or add views etc
 cp owid-public.db owid-private.db

--- a/sqlite-from-mysql.sh
+++ b/sqlite-from-mysql.sh
@@ -17,6 +17,8 @@ set +o allexport
 # pipe this into mysql2sqlite and pipe this into sqlite3 to create owid.db.
 # we need the additional `sed` command to replace string literals like `_utf8mb4'$.slug'`, which
 # mysql generates for generated columns, with just `$.slug`.
+# we also need to replace `JSON_UNQUOTE(JSON_EXTRACT())` with just `JSON_EXTRACT()`, because
+# always does JSON_UNQUOTE(), but doesn't know the function name.
 mysqldump --skip-extended-insert --no-tablespaces --column-statistics=0 --compact --port \
     $DB_PORT --password=$DB_PASSWD --user $DB_USER --host $DB_HOST $DB_NAME \
     users \
@@ -41,6 +43,7 @@ mysqldump --skip-extended-insert --no-tablespaces --column-statistics=0 --compac
     posts_gdocs_x_tags \
   | ./mysql2sqlite - \
   | sed 's/_utf8mb4//g' \
+  | sed 's/JSON_UNQUOTE(JSON_EXTRACT(/(JSON_EXTRACT(/gi' \
   | sqlite3 owid-public.db
 # Run the postprocess-db python script. This is the place to censor some rows or add views etc
 cp owid-public.db owid-private.db


### PR DESCRIPTION
The mysqldump looks something like this:
```sql
ALTER TABLE charts
ADD COLUMN slug VARCHAR(255) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(config, _utf8mb4'$.slug'))) VIRTUAL
```

We want to transform it to this sqlite-compatible version:
```sql
ALTER TABLE charts
ADD COLUMN slug VARCHAR(255) GENERATED ALWAYS AS ((JSON_EXTRACT(config, '$.slug'))) VIRTUAL
```