### PR TITLE
feat: add copy and external link buttons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
 ADD docker-entrypoint.sh docker-entrypoint.sh
 ADD requirements.txt requirements.txt
 ADD metadata.yml metadata.yml
+ADD static-files static-files
 
 RUN pip install https://github.com/simonw/datasette/archive/refs/tags/${VERSION}.zip && \
     rm -rf /root/.cache/pip

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,4 +4,4 @@ set -o pipefail
 set -o nounset
 
 wget -O - https://files.ourworldindata.org/owid.db.gz?nocache | gunzip -c > /tmp/owid.db
-datasette -h 0.0.0.0 --cors -m metadata.yml --setting sql_time_limit_ms 4000 --setting default_cache_ttl 3600 --setting max_returned_rows 6000 --setting facet_time_limit_ms 1000  /tmp/owid.db
+datasette -h 0.0.0.0 --cors -m metadata.yml --setting sql_time_limit_ms 4000 --setting default_cache_ttl 3600 --setting max_returned_rows 6000 --setting facet_time_limit_ms 1000  /tmp/owid.db --static assets:static-files/

--- a/metadata.yml
+++ b/metadata.yml
@@ -105,3 +105,8 @@ databases:
           Charts where there's an origin URL set, but no post exists for that URL.
           Sometimes this just means that a redirect has been set up in the meantime, and so the link still works for the user.
           However, in this case we still display the outdated post URL with the chart - and, crucially, there will not be any "related charts" presented to the user, since these are based on the origin URL and don't take redirects into account.
+extra_css_urls:
+  - "https://use.fontawesome.com/releases/v5.15.4/css/all.css"
+  - "/assets/owid-styles.css"
+extra_js_urls:
+  - { "url": "/assets/owid-scripts.js", "module": true }

--- a/metadata.yml
+++ b/metadata.yml
@@ -106,7 +106,7 @@ databases:
           Sometimes this just means that a redirect has been set up in the meantime, and so the link still works for the user.
           However, in this case we still display the outdated post URL with the chart - and, crucially, there will not be any "related charts" presented to the user, since these are based on the origin URL and don't take redirects into account.
 extra_css_urls:
-  - "https://use.fontawesome.com/releases/v5.15.4/css/all.css"
+  - "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
   - "/assets/owid-styles.css"
 extra_js_urls:
   - { "url": "/assets/owid-scripts.js", "module": true }

--- a/static-files/owid-scripts.js
+++ b/static-files/owid-scripts.js
@@ -12,6 +12,7 @@ const addCopyButtonToCell = (buttonsContainer, value) => {
 
 const externalUrlFields = [
   {
+    // Chart slug
     colNames: [
       "owid.charts.slug",
       "owid.slug",
@@ -21,8 +22,29 @@ const externalUrlFields = [
     fn: (slug) => `https://ourworldindata.org/grapher/${slug}`,
   },
   {
+    // Chart ID
     colNames: ["owid.charts.id", "owid.chartId", "owid.grapherId"],
     fn: (id) => `https://owid.cloud/admin/charts/${id}/edit`,
+  },
+  {
+    // Variable ID
+    colNames: ["owid.variables.id", "owid.variableId"],
+    fn: (id) => `https://owid.cloud/admin/variables/${id}`,
+  },
+  {
+    // Dataset ID
+    colNames: ["owid.datasets.id", "owid.datasetId"],
+    fn: (id) => `https://owid.cloud/admin/datasets/${id}`,
+  },
+  {
+    // Tag ID
+    colNames: ["owid.tags.id", "owid.tagId"],
+    fn: (id) => `https://owid.cloud/admin/tags/${id}`,
+  },
+  {
+    // Post slug
+    colNames: ["owid.posts.slug", "owid.posts_gdocs.slug", "owid.postSlug"],
+    fn: (slug) => `https://ourworldindata.org/${slug}`,
   },
 ];
 

--- a/static-files/owid-scripts.js
+++ b/static-files/owid-scripts.js
@@ -2,11 +2,12 @@ const copyToClipboard = async (text) => {
   await navigator.clipboard.writeText(text);
 };
 
-const addCopyButtonToCell = (cell, value) => {
+const addCopyButtonToCell = (buttonsContainer, value) => {
   const copyButton = document.createElement("a");
   copyButton.className = "owid-button owid-copy-button fa fa-copy";
+  copyButton.title = "Copy to clipboard";
   copyButton.onclick = () => copyToClipboard(value);
-  cell.append(copyButton);
+  buttonsContainer.append(copyButton);
 };
 
 const externalUrlFields = [
@@ -35,7 +36,7 @@ const externalUrlByFieldName = externalUrlFields.reduce(
   {}
 );
 
-const addExternalUrlButtonToCell = (cell, fieldName, value) => {
+const addExternalUrlButtonToCell = (buttonsContainer, fieldName, value) => {
   const href = externalUrlByFieldName[fieldName]?.(value);
 
   if (!href) return;
@@ -44,8 +45,9 @@ const addExternalUrlButtonToCell = (cell, fieldName, value) => {
     "owid-button owid-external-url-button fa fa-external-link-alt";
   externalUrlButton.target = "_blank";
   externalUrlButton.rel = "noopener noreferrer";
+  externalUrlButton.title = "Open in new tab";
   externalUrlButton.href = href;
-  cell.appendChild(externalUrlButton);
+  buttonsContainer.appendChild(externalUrlButton);
 };
 
 let databaseName;
@@ -60,9 +62,13 @@ body.classList.forEach((className) => {
 const cells = document.querySelectorAll("table.rows-and-columns td");
 cells.forEach((cell) => {
   const value = cell.innerText;
-  if (!value) return;
+  if (!value?.trim?.()) return;
 
-  addCopyButtonToCell(cell, value);
+  const buttonsContainer = document.createElement("div");
+  buttonsContainer.className = "owid-buttons";
+  cell.appendChild(buttonsContainer);
+
+  addCopyButtonToCell(buttonsContainer, value);
 
   let colName;
   cell.classList.forEach((className) => {
@@ -72,5 +78,5 @@ cells.forEach((cell) => {
   const fieldName = [databaseName, tableName, colName]
     .filter((f) => f)
     .join(".");
-  addExternalUrlButtonToCell(cell, fieldName, value);
+  addExternalUrlButtonToCell(buttonsContainer, fieldName, value);
 });

--- a/static-files/owid-scripts.js
+++ b/static-files/owid-scripts.js
@@ -1,0 +1,17 @@
+const copyToClipboard = async (text) => {
+  await navigator.clipboard.writeText(text);
+};
+
+const addCopyButtonToCell = (cell, value) => {
+  const copyButton = document.createElement("button");
+  copyButton.className = "owid-copy-button fa fa-copy";
+  copyButton.onclick = () => copyToClipboard(value);
+  cell.append(copyButton);
+};
+
+const cells = document.querySelectorAll("table.rows-and-columns td");
+cells.forEach((cell) => {
+  const value = cell.innerText;
+
+  addCopyButtonToCell(cell, value);
+});

--- a/static-files/owid-scripts.js
+++ b/static-files/owid-scripts.js
@@ -94,7 +94,7 @@ const addExternalUrlButtonToCell = (
 
   const externalUrlButton = document.createElement("a");
   externalUrlButton.className =
-    "owid-button owid-external-url-button fa fa-external-link-alt";
+    "owid-button owid-external-url-button fa fa-external-link";
   externalUrlButton.target = "_blank";
   externalUrlButton.rel = "noopener noreferrer";
   externalUrlButton.title = "Open in new tab";

--- a/static-files/owid-scripts.js
+++ b/static-files/owid-scripts.js
@@ -50,6 +50,13 @@ const addExternalUrlButtonToCell = (buttonsContainer, fieldName, value) => {
   buttonsContainer.appendChild(externalUrlButton);
 };
 
+const wrapInDetailsElement = (element) => {
+  const detail = document.createElement("details");
+  detail.className = "owid-detail";
+  element.parentNode.insertBefore(detail, element);
+  detail.appendChild(element);
+};
+
 let databaseName;
 let tableName;
 const body = document.body;
@@ -64,12 +71,15 @@ cells.forEach((cell) => {
   const value = cell.innerText;
   if (!value?.trim?.()) return;
 
+  // Add "owid-buttons" container for any buttons
   const buttonsContainer = document.createElement("div");
   buttonsContainer.className = "owid-buttons";
   cell.appendChild(buttonsContainer);
 
+  // Add a copy button
   addCopyButtonToCell(buttonsContainer, value);
 
+  // Add an external URL button, linking to the grapher/admin etc.
   let colName;
   cell.classList.forEach((className) => {
     if (className.startsWith("col-")) colName = className.replace("col-", "");
@@ -79,4 +89,10 @@ cells.forEach((cell) => {
     .filter((f) => f)
     .join(".");
   addExternalUrlButtonToCell(buttonsContainer, fieldName, value);
+
+  // Wrap config JSON in a <details> tag
+  if (cell.classList.contains("col-config")) {
+    const pre = cell.querySelector("pre");
+    if (pre) wrapInDetailsElement(pre);
+  }
 });

--- a/static-files/owid-scripts.js
+++ b/static-files/owid-scripts.js
@@ -9,13 +9,34 @@ const addCopyButtonToCell = (cell, value) => {
   cell.append(copyButton);
 };
 
-const externalUrlFields = {
-  "owid.charts.slug": (slug) => `https://ourworldindata.org/grapher/${slug}`,
-  "owid.charts.id": (id) => `https://owid.cloud/admin/charts/${id}/edit`,
-};
+const externalUrlFields = [
+  {
+    colNames: [
+      "owid.charts.slug",
+      "owid.slug",
+      "owid.chartSlug",
+      "owid.grapherSlug",
+    ],
+    fn: (slug) => `https://ourworldindata.org/grapher/${slug}`,
+  },
+  {
+    colNames: ["owid.charts.id", "owid.chartId", "owid.grapherId"],
+    fn: (id) => `https://owid.cloud/admin/charts/${id}/edit`,
+  },
+];
 
-const addExternalUrlButtonToCell = (cell, field, value) => {
-  const href = externalUrlFields[field]?.(value);
+const externalUrlByFieldName = externalUrlFields.reduce(
+  (acc, { colNames, fn }) => {
+    colNames.forEach((colName) => {
+      acc[colName] = fn;
+    });
+    return acc;
+  },
+  {}
+);
+
+const addExternalUrlButtonToCell = (cell, fieldName, value) => {
+  const href = externalUrlByFieldName[fieldName]?.(value);
 
   if (!href) return;
   const externalUrlButton = document.createElement("a");
@@ -48,8 +69,8 @@ cells.forEach((cell) => {
     if (className.startsWith("col-")) colName = className.replace("col-", "");
   });
 
-  if (databaseName && tableName && colName) {
-    const field = `${databaseName}.${tableName}.${colName}`;
-    addExternalUrlButtonToCell(cell, field, value);
-  }
+  const fieldName = [databaseName, tableName, colName]
+    .filter((f) => f)
+    .join(".");
+  addExternalUrlButtonToCell(cell, fieldName, value);
 });

--- a/static-files/owid-scripts.js
+++ b/static-files/owid-scripts.js
@@ -3,15 +3,53 @@ const copyToClipboard = async (text) => {
 };
 
 const addCopyButtonToCell = (cell, value) => {
-  const copyButton = document.createElement("button");
-  copyButton.className = "owid-copy-button fa fa-copy";
+  const copyButton = document.createElement("a");
+  copyButton.className = "owid-button owid-copy-button fa fa-copy";
   copyButton.onclick = () => copyToClipboard(value);
   cell.append(copyButton);
 };
 
+const externalUrlFields = {
+  "owid.charts.slug": (slug) => `https://ourworldindata.org/grapher/${slug}`,
+  "owid.charts.id": (id) => `https://owid.cloud/admin/charts/${id}/edit`,
+};
+
+const addExternalUrlButtonToCell = (cell, field, value) => {
+  const href = externalUrlFields[field]?.(value);
+
+  if (!href) return;
+  const externalUrlButton = document.createElement("a");
+  externalUrlButton.className =
+    "owid-button owid-external-url-button fa fa-external-link-alt";
+  externalUrlButton.target = "_blank";
+  externalUrlButton.rel = "noopener noreferrer";
+  externalUrlButton.href = href;
+  cell.appendChild(externalUrlButton);
+};
+
+let databaseName;
+let tableName;
+const body = document.body;
+body.classList.forEach((className) => {
+  if (className.startsWith("db-")) databaseName = className.replace("db-", "");
+  else if (className.startsWith("table-"))
+    tableName = className.replace("table-", "");
+});
+
 const cells = document.querySelectorAll("table.rows-and-columns td");
 cells.forEach((cell) => {
   const value = cell.innerText;
+  if (!value) return;
 
   addCopyButtonToCell(cell, value);
+
+  let colName;
+  cell.classList.forEach((className) => {
+    if (className.startsWith("col-")) colName = className.replace("col-", "");
+  });
+
+  if (databaseName && tableName && colName) {
+    const field = `${databaseName}.${tableName}.${colName}`;
+    addExternalUrlButtonToCell(cell, field, value);
+  }
 });

--- a/static-files/owid-scripts.js
+++ b/static-files/owid-scripts.js
@@ -51,6 +51,11 @@ const externalUrlFields = [
     colNames: ["owid.posts.slug", "owid.posts_gdocs.slug", "owid.postSlug"],
     fn: (slug) => `https://ourworldindata.org/${slug}`,
   },
+  {
+    // Gdocs post identifier
+    colNames: ["owid.posts_gdocs.id", "owid/posts_gdocs"],
+    fn: (id) => `https://owid.cloud/admin/gdocs/${id}/preview`,
+  },
 ];
 
 const externalUrlByFieldName = externalUrlFields.reduce(
@@ -138,7 +143,10 @@ cells.forEach((cell) => {
   addExternalUrlButtonToCell(cell, buttonsContainer, fieldName, value);
 
   // Wrap config JSON in a <details> tag
-  if (cell.classList.contains("col-config")) {
+  if (
+    cell.classList.contains("col-config") ||
+    cell.classList.contains("col-content")
+  ) {
     const pre = cell.querySelector("pre");
     if (pre) wrapInDetailsElement(pre);
   }

--- a/static-files/owid-styles.css
+++ b/static-files/owid-styles.css
@@ -1,4 +1,4 @@
-.owid-copy-button {
+.owid-button {
   position: relative;
   margin-left: 5px;
   font-size: 0.7em;
@@ -11,4 +11,8 @@
 
 table.rows-and-columns td {
   max-width: 60vw;
+}
+
+table td pre {
+  white-space: pre-wrap;
 }

--- a/static-files/owid-styles.css
+++ b/static-files/owid-styles.css
@@ -10,7 +10,7 @@
 .owid-button, a.owid-button {
   position: relative;
   font-size: 0.7em;
-  color: black;
+  color: rgba(0, 0, 0, 0.3);
   cursor: pointer;
 }
 

--- a/static-files/owid-styles.css
+++ b/static-files/owid-styles.css
@@ -1,0 +1,14 @@
+.owid-copy-button {
+  position: relative;
+  margin-left: 5px;
+  font-size: 0.7em;
+  background-color: #fff;
+  color: #666;
+  border: 1px solid #eee;
+  cursor: pointer;
+  float: right;
+}
+
+table.rows-and-columns td {
+  max-width: 60vw;
+}

--- a/static-files/owid-styles.css
+++ b/static-files/owid-styles.css
@@ -1,16 +1,34 @@
-.owid-button {
+.owid-buttons {
+  position: absolute;
+  top: .5em;
+  right: .5em;
+  display: flex;
+  flex-direction: row;
+  gap: .5em;
+}
+
+.owid-button, a.owid-button {
   position: relative;
-  margin-left: 5px;
   font-size: 0.7em;
-  background-color: #fff;
-  color: #666;
-  border: 1px solid #eee;
+  color: black;
   cursor: pointer;
-  float: right;
+}
+
+.owid-button:hover, a.owid-button:hover {
+  color: #555;
 }
 
 table.rows-and-columns td {
   max-width: 60vw;
+  position: relative;
+}
+
+.owid-copy-button {
+  display: none;
+}
+
+table.rows-and-columns td:hover .owid-copy-button {
+  display: block;
 }
 
 table td pre {


### PR DESCRIPTION
## Features:
- Every cell gets a Copy to clipboard button that appears on cell hover
- Many cells, like variable ids and slugs, get links that go to the chart or admin page
	- They also appear on columns called `grapherSlug`, `variableId`, etc. as a heuristic
	- They also appear on foreign key links that Datasette presents
- As an additional feature, JSON fields called `config` or `content` get wrapped into a `<details>` element (which is still searchable using Cmd-F, which is nice)

<img width="1442" alt="image" src="https://github.com/owid/owid-datasette/assets/2641501/41f5ef61-b670-4a3b-a971-a9d2fa07d99b">

<img width="1395" alt="image" src="https://github.com/owid/owid-datasette/assets/2641501/82e54e07-8343-4a58-8280-a826f162b7af">

<img width="474" alt="image" src="https://github.com/owid/owid-datasette/assets/2641501/81f95766-2e80-47ee-96a4-a00d5f8a4795">
